### PR TITLE
Use Model from Config for Resource

### DIFF
--- a/src/Resources/MailResource.php
+++ b/src/Resources/MailResource.php
@@ -29,8 +29,6 @@ use Vormkracht10\Mails\Models\MailEvent;
 
 class MailResource extends Resource
 {
-    protected static ?string $model = Mail::class;
-
     protected static ?string $slug = 'mails';
 
     protected static ?string $recordTitleAttribute = 'subject';
@@ -38,6 +36,11 @@ class MailResource extends Resource
     protected static bool $isScopedToTenant = false;
 
     protected static bool $shouldRegisterNavigation = true;
+
+    public static function getModel(): string
+    {
+        return config('mails.models.mail');
+    }
 
     public static function getNavigationGroup(): ?string
     {


### PR DESCRIPTION
If you customize the model in config, it's not used in this resource. This fixes that problem.