### PR TITLE
[Fix] Return empty array when $record's to, cc or bcc is empty (#18)

### DIFF
--- a/src/Resources/MailResource.php
+++ b/src/Resources/MailResource.php
@@ -386,9 +386,9 @@ class MailResource extends Resource
                     ->form(self::getResendForm())
                     ->fillForm(function (Mail $record) {
                         return [
-                            'to' => array_keys($record->to),
-                            'cc' => array_keys($record->cc),
-                            'bcc' => array_keys($record->bcc),
+                            'to' => array_keys($record->to ?: []),
+                            'cc' => array_keys($record->cc ?: []),
+                            'bcc' => array_keys($record->bcc ?: []),
                         ];
                     })
                     ->action(function (Mail $record, array $data) {


### PR DESCRIPTION
Fixes bug #18.