### PR TITLE
change rules to nestedRecursiveRules

### DIFF
--- a/src/Resources/MailResource.php
+++ b/src/Resources/MailResource.php
@@ -436,15 +436,15 @@ class MailResource extends Resource
                 ->placeholder(__('Recipient(s)'))
                 ->label(__('To'))
                 ->required()
-                ->rules(['email:rfc,dns']),
+                ->nestedRecursiveRules(['email:rfc,dns']),
             TagsInput::make('cc')
                 ->placeholder(__('Recipient(s)'))
                 ->label(__('CC'))
-                ->rules(['nullable', 'email:rfc,dns']),
+                ->nestedRecursiveRules(['nullable', 'email:rfc,dns']),
             TagsInput::make('bcc')
                 ->placeholder(__('Recipient(s)'))
                 ->label(__('BCC'))
-                ->rules(['nullable', 'email:rfc,dns']),
+                ->nestedRecursiveRules(['nullable', 'email:rfc,dns']),
         ];
     }
 


### PR DESCRIPTION
This PR fixes the validation issue with the TagsInput fields (to, cc, bcc) by replacing rules() with nestedRecursiveRules(). Since these fields are cast to JSON in the database, using standard rules() was not applying validation correctly to individual email addresses within the tag input.