### PR TITLE
fix: validation rules TagsInput fields

### DIFF
--- a/src/Resources/MailResource.php
+++ b/src/Resources/MailResource.php
@@ -436,15 +436,15 @@ class MailResource extends Resource
                 ->placeholder(__('Recipient(s)'))
                 ->label(__('To'))
                 ->required()
-                ->rules(['email:rfc,dns']),
+                ->nestedRecursiveRules(['email:rfc,dns']),
             TagsInput::make('cc')
                 ->placeholder(__('Recipient(s)'))
                 ->label(__('CC'))
-                ->rules(['nullable', 'email:rfc,dns']),
+                ->nestedRecursiveRules(['nullable', 'email:rfc,dns']),
             TagsInput::make('bcc')
                 ->placeholder(__('Recipient(s)'))
                 ->label(__('BCC'))
-                ->rules(['nullable', 'email:rfc,dns']),
+                ->nestedRecursiveRules(['nullable', 'email:rfc,dns']),
         ];
     }
 


### PR DESCRIPTION
The validation rules using rules() on TagsInput fields (to, cc, and bcc) are not working as expected because these fields are cast to JSON in the model.