### PR TITLE
Fix issue with navigation icons

### DIFF
--- a/src/Resources/EventResource.php
+++ b/src/Resources/EventResource.php
@@ -60,7 +60,7 @@ class EventResource extends Resource
         return __('Events');
     }
 
-    public static function getNavigationIcon(): string
+    public static function getNavigationIcon(): ?string
     {
         return 'heroicon-o-calendar';
     }

--- a/src/Resources/MailResource.php
+++ b/src/Resources/MailResource.php
@@ -60,7 +60,7 @@ class MailResource extends Resource
         return __('Email');
     }
 
-    public static function getNavigationIcon(): string
+    public static function getNavigationIcon(): ?string
     {
         return 'heroicon-o-envelope';
     }

--- a/src/Resources/SuppressionResource.php
+++ b/src/Resources/SuppressionResource.php
@@ -59,7 +59,7 @@ class SuppressionResource extends Resource
         return __('Suppressions');
     }
 
-    public static function getNavigationIcon(): string
+    public static function getNavigationIcon(): ?string
     {
         return 'heroicon-o-no-symbol';
     }


### PR DESCRIPTION
In Filament, the `getNavigationIcon` can return null, which allows for disabling the navigation icon.

In this plugin, the method on the resources forces the `string` return type, which prevents any override of the resource from removing the icon.