### PR TITLE
Check if is array on SuppressionResource

### DIFF
--- a/src/Resources/SuppressionResource.php
+++ b/src/Resources/SuppressionResource.php
@@ -101,14 +101,14 @@ class SuppressionResource extends Resource
             ->columns([
                 Tables\Columns\TextColumn::make('to')
                     ->label(__('Email address'))
-                    ->formatStateUsing(fn ($record) => key(json_decode($record->to ?? [])))
+                    ->formatStateUsing(fn($record) => key(json_decode($record->to ?? [])))
                     ->searchable(['to']),
 
                 Tables\Columns\TextColumn::make('id')
                     ->label(__('Reason'))
                     ->badge()
-                    ->formatStateUsing(fn ($record) => $record->type->value == EventType::COMPLAINED->value ? 'Complained' : 'Bounced')
-                    ->color(fn ($record): string => match ($record->type->value == EventType::COMPLAINED->value) {
+                    ->formatStateUsing(fn($record) => $record->type->value == EventType::COMPLAINED->value ? 'Complained' : 'Bounced')
+                    ->color(fn($record): string => match ($record->type->value == EventType::COMPLAINED->value) {
                         true => 'danger',
                         default => 'gray',
                     }),
@@ -117,7 +117,7 @@ class SuppressionResource extends Resource
                     ->label(__('Occurred At'))
                     ->dateTime('d-m-Y H:i')
                     ->since()
-                    ->tooltip(fn (MailEvent $record) => $record->occurred_at->format('d-m-Y H:i'))
+                    ->tooltip(fn(MailEvent $record) => $record->occurred_at->format('d-m-Y H:i'))
                     ->sortable()
                     ->searchable(),
             ])
@@ -125,9 +125,9 @@ class SuppressionResource extends Resource
                 Tables\Actions\Action::make('unsuppress')
                     ->label(__('Unsuppress'))
                     ->action(function (MailEvent $record) {
-                        event(new MailUnsuppressed(key($record->to), $record->mail->mailer == 'smtp' && filled($record->mail->transport) ? $record->mail->transport : $record->mail->mailer, $record->mail->stream_id ?? null));
+                        event(new MailUnsuppressed(is_array($record->to) ? key($record->to) : $record->to, $record->mail->mailer == 'smtp' && filled($record->mail->transport) ? $record->mail->transport : $record->mail->mailer, $record->mail->stream_id ?? null));
                     })
-                    ->visible(fn ($record) => Provider::tryFrom($record->mail->mailer == 'smtp' && filled($record->mail->transport) ? $record->mail->transport : $record->mail->mailer)),
+                    ->visible(fn($record) => Provider::tryFrom($record->mail->mailer == 'smtp' && filled($record->mail->transport) ? $record->mail->transport : $record->mail->mailer)),
 
                 Tables\Actions\ViewAction::make()
                     ->url(null)
@@ -136,7 +136,7 @@ class SuppressionResource extends Resource
                     ->label(__('View'))
                     ->hiddenLabel()
                     ->tooltip(__('View'))
-                    ->infolist(fn (Infolist $infolist) => EventResource::infolist($infolist)),
+                    ->infolist(fn(Infolist $infolist) => EventResource::infolist($infolist)),
             ]);
     }
 

--- a/src/Resources/SuppressionResource.php
+++ b/src/Resources/SuppressionResource.php
@@ -125,7 +125,7 @@ class SuppressionResource extends Resource
                 Tables\Actions\Action::make('unsuppress')
                     ->label(__('Unsuppress'))
                     ->action(function (MailEvent $record) {
-                        event(new MailUnsuppressed(is_array($record->to) ? key($record->to) : $record->to, $record->mail->mailer == 'smtp' && filled($record->mail->transport) ? $record->mail->transport : $record->mail->mailer, $record->mail->stream_id ?? null));
+                        event(new MailUnsuppressed(is_array($record->to) ? key($record->to) : key(json_decode($record->to, true)), $record->mail->mailer == 'smtp' && filled($record->mail->transport) ? $record->mail->transport : $record->mail->mailer, $record->mail->stream_id ?? null));
                     })
                     ->visible(fn($record) => Provider::tryFrom($record->mail->mailer == 'smtp' && filled($record->mail->transport) ? $record->mail->transport : $record->mail->mailer)),
 


### PR DESCRIPTION
This pull request includes a change to the `table` method in the `SuppressionResource` class to handle cases where the `to` field is a JSON-encoded string.

* [`src/Resources/SuppressionResource.php`](diffhunk://#diff-8dbe5db634b56167e348f358899d3a518268d7e92a27366c00a14f4750f16b16L128-R128): Modified the `unsuppress` action to decode the `to` field if it is a JSON-encoded string.